### PR TITLE
change suggested RCS properties

### DIFF
--- a/connector/properties/development/ConnectorServer.properties
+++ b/connector/properties/development/ConnectorServer.properties
@@ -46,7 +46,7 @@ connectorserver.housekeepingInterval=20
 ##
 ## The WebSockets groups check interval (seconds)
 ##
-connectorserver.groupCheckInterval=900
+connectorserver.groupCheckInterval=60
 ##
 ## Number of websocket connections to open
 ##
@@ -54,7 +54,7 @@ connectorserver.webSocketConnections=3
 ##
 ## Time to live of a websocket connection (seconds)
 ##
-connectorserver.connectionTtl=3000
+connectorserver.connectionTtl=300
 ##
 ## New Connections interval (seconds)
 ##

--- a/connector/properties/live/ConnectorServer.properties
+++ b/connector/properties/live/ConnectorServer.properties
@@ -46,7 +46,7 @@ connectorserver.housekeepingInterval=20
 ##
 ## The WebSockets groups check interval (seconds)
 ##
-connectorserver.groupCheckInterval=900
+connectorserver.groupCheckInterval=60
 ##
 ## Number of websocket connections to open
 ##
@@ -54,7 +54,7 @@ connectorserver.webSocketConnections=3
 ##
 ## Time to live of a websocket connection (seconds)
 ##
-connectorserver.connectionTtl=3000
+connectorserver.connectionTtl=300
 ##
 ## New Connections interval (seconds)
 ##

--- a/connector/properties/staging/ConnectorServer.properties
+++ b/connector/properties/staging/ConnectorServer.properties
@@ -46,7 +46,7 @@ connectorserver.housekeepingInterval=20
 ##
 ## The WebSockets groups check interval (seconds)
 ##
-connectorserver.groupCheckInterval=900
+connectorserver.groupCheckInterval=60
 ##
 ## Number of websocket connections to open
 ##
@@ -54,7 +54,7 @@ connectorserver.webSocketConnections=3
 ##
 ## Time to live of a websocket connection (seconds)
 ##
-connectorserver.connectionTtl=3000
+connectorserver.connectionTtl=300
 ##
 ## New Connections interval (seconds)
 ##


### PR DESCRIPTION
Raising on forgerocks advice:

Hi Sam, 

For the RCS ConnectorServer.properties, we now advise setting, unless this was previously advised to have the current value. 
 
```
The WebSockets group check interval (seconds)

connectorserver.groupCheckInterval=60

and

Time to live of a websocket connection (seconds)

connectorserver.connectionTtl=300
```

This is related to the RCS connections issues we are seeing at the moment in Production. 
The changes only affect properties on the RCS servers config in an attempt to improve connection stability to FIDC. 