### PR TITLE
Update RCS connector properties

### DIFF
--- a/connector/properties/development/ConnectorServer.properties
+++ b/connector/properties/development/ConnectorServer.properties
@@ -46,7 +46,7 @@ connectorserver.housekeepingInterval=20
 ##
 ## The WebSockets groups check interval (seconds)
 ##
-connectorserver.groupCheckInterval=900
+connectorserver.groupCheckInterval=60
 ##
 ## Number of websocket connections to open
 ##
@@ -54,7 +54,7 @@ connectorserver.webSocketConnections=3
 ##
 ## Time to live of a websocket connection (seconds)
 ##
-connectorserver.connectionTtl=3000
+connectorserver.connectionTtl=300
 ##
 ## New Connections interval (seconds)
 ##

--- a/connector/properties/live/ConnectorServer.properties
+++ b/connector/properties/live/ConnectorServer.properties
@@ -46,7 +46,7 @@ connectorserver.housekeepingInterval=20
 ##
 ## The WebSockets groups check interval (seconds)
 ##
-connectorserver.groupCheckInterval=900
+connectorserver.groupCheckInterval=60
 ##
 ## Number of websocket connections to open
 ##
@@ -54,7 +54,7 @@ connectorserver.webSocketConnections=3
 ##
 ## Time to live of a websocket connection (seconds)
 ##
-connectorserver.connectionTtl=3000
+connectorserver.connectionTtl=300
 ##
 ## New Connections interval (seconds)
 ##

--- a/connector/properties/staging/ConnectorServer.properties
+++ b/connector/properties/staging/ConnectorServer.properties
@@ -46,7 +46,7 @@ connectorserver.housekeepingInterval=20
 ##
 ## The WebSockets groups check interval (seconds)
 ##
-connectorserver.groupCheckInterval=900
+connectorserver.groupCheckInterval=60
 ##
 ## Number of websocket connections to open
 ##
@@ -54,7 +54,7 @@ connectorserver.webSocketConnections=3
 ##
 ## Time to live of a websocket connection (seconds)
 ##
-connectorserver.connectionTtl=3000
+connectorserver.connectionTtl=300
 ##
 ## New Connections interval (seconds)
 ##


### PR DESCRIPTION
# WHAT
Change RCS connector properties to increase connection stability

# WHY
There is a consistent error relating to the WebSockets timing out. Changing the following attributes should provide some stability:
 - `groupCheckInterval` - Interval at which RCS checks WebSocket connection groups 
 - `connectionTtl` - Time to live of a WebSocket connection

# HOW
- `connectorserver.groupCheckInterval`=900 should be 60
- `connectorserver.connectionTtl`=3000 should be 300