### PR TITLE
Reverting changes for the RCS connector update

### DIFF
--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -34,8 +34,8 @@ RUN if [[ -n "${DB_TABLE_VERSION}" ]] ; then rm connectors/databasetable-connect
 RUN if [[ -n "${DB_TABLE_VERSION}" ]] ; then mv databasetable-connector-${DB_TABLE_VERSION}.jar connectors ; fi
 
 # Download Oracle JDBC driver if argument is set
-RUN if [[ -n "${ORACLE_DRIVER_VERSION}" ]] ; then aws s3 cp s3://development-eu-west-2.resources.ch.gov.uk/packages/forgerock/ojdbc17-${ORACLE_DRIVER_VERSION}.jar . ; fi
-RUN if [[ -n "${ORACLE_DRIVER_VERSION}" ]] ; then mv ojdbc17-${ORACLE_DRIVER_VERSION}.jar lib/framework ; fi
+RUN if [[ -n "${ORACLE_DRIVER_VERSION}" ]] ; then aws s3 cp s3://development-eu-west-2.resources.ch.gov.uk/packages/forgerock/ojdbc7-${ORACLE_DRIVER_VERSION}.jar . ; fi
+RUN if [[ -n "${ORACLE_DRIVER_VERSION}" ]] ; then mv ojdbc7-${ORACLE_DRIVER_VERSION}.jar lib/framework ; fi
 
 
 FROM eclipse-temurin:17-jdk


### PR DESCRIPTION
Reverting changes for the RCS connector update 

This is being rolled back to the older version