### PR TITLE
Add Template provider directly for EWF

### DIFF
--- a/terraform/groups/ewf/provider.tf
+++ b/terraform/groups/ewf/provider.tf
@@ -6,6 +6,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+
+    template = {
+      source = "hashicorp/template"
+      version = "2.2.0"
+    }
   }
 }
 


### PR DESCRIPTION
Adds the template provider into EWF terraform directly which resolves issue with it not being found for the decom plan. 